### PR TITLE
Removed syn crate private dependencies usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 name = "waiter_codegen"
 version = "1.6.4"
 dependencies = [
+ "proc-macro2",
  "quote",
  "regex",
  "syn",

--- a/crates/waiter_codegen/Cargo.toml
+++ b/crates/waiter_codegen/Cargo.toml
@@ -11,6 +11,7 @@ authors = [ "dmitryb.dev@gmail.com" ]
 [dependencies]
 quote = "1.0.7"
 regex = "1.3.9"
+proc-macro2 = "1.0.24"
 
 [dependencies.syn]
 version = "1.0.48"

--- a/crates/waiter_codegen/src/attr_parser.rs
+++ b/crates/waiter_codegen/src/attr_parser.rs
@@ -1,10 +1,12 @@
 use syn::{Path, Error, Attribute};
 use syn::punctuated::Punctuated;
 use syn::parse::Parser;
-use syn::export::{TokenStream, TokenStream2, ToTokens};
 use syn::token::{Comma};
 use syn::{LitStr, ExprAssign};
 use syn::parse_macro_input::parse;
+use proc_macro::TokenStream;
+use proc_macro2::{TokenStream as TokenStream2};
+use quote::ToTokens;
 
 pub(crate) struct ProvidesAttr {
     pub profiles: Vec<Path>

--- a/crates/waiter_codegen/src/component/injector.rs
+++ b/crates/waiter_codegen/src/component/injector.rs
@@ -1,5 +1,6 @@
+use proc_macro2::{TokenStream as TokenStream2};
+use quote::ToTokens;
 use syn::{Ident, Error, PathArguments};
-use syn::export::{TokenStream2, ToTokens};
 use syn::spanned::Spanned;
 use crate::component::type_to_inject::TypeToInject;
 

--- a/crates/waiter_codegen/src/component/mod.rs
+++ b/crates/waiter_codegen/src/component/mod.rs
@@ -1,9 +1,10 @@
 use proc_macro::{TokenStream};
+use proc_macro2::{TokenStream as TokenStream2, Span};
+use quote;
+use quote::ToTokens;
 use syn::{Ident, ItemStruct, Fields, Field, Type, Error, PathArguments, GenericArgument, ItemImpl, ImplItem, Expr, ItemFn};
-use syn::export::{TokenStream2, Span, ToTokens};
 use crate::component::injector::{WrcInjector, DeferredInjector, BoxInjector, ConfigInjector,
                           Injector, PropInjector};
-use syn::export::quote;
 use syn::spanned::Spanned;
 use crate::attr_parser::parse_provides_attr;
 use crate::provider::generate_component_provider_impl_fn;

--- a/crates/waiter_codegen/src/component/type_to_inject.rs
+++ b/crates/waiter_codegen/src/component/type_to_inject.rs
@@ -1,4 +1,5 @@
-use syn::export::{TokenStream2, ToTokens};
+use proc_macro2::{TokenStream as TokenStream2};
+use quote::ToTokens;
 use crate::attr_parser::{PropAttr, parse_prop_attr};
 use syn::{Path, Error, Type, Field, FnArg, Attribute, Pat};
 use syn::spanned::Spanned;

--- a/crates/waiter_codegen/src/lib.rs
+++ b/crates/waiter_codegen/src/lib.rs
@@ -1,10 +1,11 @@
 use proc_macro::TokenStream;
+use proc_macro2::{TokenStream as TokenStream2};
+use quote::ToTokens;
 use syn::*;
 use component::{generate_component_for_struct, generate_component_for_impl};
 use provider::*;
 use attr_parser::{parse_provides_attr};
 use syn::spanned::Spanned;
-use syn::export::{TokenStream2, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
 

--- a/crates/waiter_codegen/src/provider.rs
+++ b/crates/waiter_codegen/src/provider.rs
@@ -1,7 +1,8 @@
 use proc_macro::TokenStream;
+use proc_macro2::{TokenStream as TokenStream2};
+use quote::ToTokens;
 
 use syn::{GenericParam, ItemImpl, ItemStruct, Path, Type, ItemFn, ReturnType, Error};
-use syn::export::{TokenStream2, ToTokens};
 use std::ops::Deref;
 use crate::component::{generate_dependencies_create_code, generate_inject_dependencies_tuple};
 use syn::spanned::Spanned;


### PR DESCRIPTION
I've encountered same issue as #4 in my pet project and decided to fix it. It happened to be not so hard but any criticism appreciated as I'm still learning Rust.

Main problem if I understand correctly was in using "privates" re-exported modules in `syn` crate (it declared as `pub mod` in syn but comment says that it is private api). In later crate releases it was renamed, apperently to prevent such use cases. But I still didnt understand why waiter didnt compile if used in other project, probably cargo tried it best to satisfy dependency tree requirements and failed if some other dependency used other versions of `syn` crate.